### PR TITLE
Fix link to Google Analytics for Government manual

### DIFF
--- a/prepare-ga.md
+++ b/prepare-ga.md
@@ -52,7 +52,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 #### More reading: 
 - [Google Tag Manager Documentation](https://support.google.com/tagmanager/answer/2574370?hl=en)
-- [Google Analytics for Government](https://www.digitalgov.gov/files/2014/05/2ND_EDITION__GOOGLE_ANALYTICS_FOR_GOVERNMENT_TRAINING_MANUAL-4.pdf), Sarah Kaczmarek
+- [Google Analytics for Government](https://s3.amazonaws.com/digitalgov/_legacy-img/2014/05/2ND_EDITION__GOOGLE_ANALYTICS_FOR_GOVERNMENT_TRAINING_MANUAL-4.pdf), Sarah Kaczmarek
 
 ---
 


### PR DESCRIPTION
The existing link is broken. It looks like they moved the PDF to https://s3.amazonaws.com/digitalgov/_legacy-img/2014/05/2ND_EDITION__GOOGLE_ANALYTICS_FOR_GOVERNMENT_TRAINING_MANUAL-4.pdf . Or alternatively change the link to the blog post where I got the new PDF url (https://www.digitalgov.gov/2014/05/15/new-google-analytics-for-government-training-manual/)? I'm not sure which is better.